### PR TITLE
Fixing problems with Wikipedia dump template 

### DIFF
--- a/src/main/java/com/diffbot/wikistatsextractor/extractors/ExtractContextualToken.java
+++ b/src/main/java/com/diffbot/wikistatsextractor/extractors/ExtractContextualToken.java
@@ -455,6 +455,7 @@ public class ExtractContextualToken {
 			String line = br.readLine();
 			while (line != null) {
 				String[] split = Util.fastSplit(line);
+				//old: redirections.put(split[0], split[1]), sometimes length was 0
 				if(split.length > 1)
 					redirections.put(split[0], split[1]);
 				line = br.readLine();

--- a/src/main/java/com/diffbot/wikistatsextractor/extractors/ExtractContextualToken.java
+++ b/src/main/java/com/diffbot/wikistatsextractor/extractors/ExtractContextualToken.java
@@ -455,7 +455,8 @@ public class ExtractContextualToken {
 			String line = br.readLine();
 			while (line != null) {
 				String[] split = Util.fastSplit(line);
-				redirections.put(split[0], split[1]);
+				if(split.length > 1)
+					redirections.put(split[0], split[1]);
 				line = br.readLine();
 			}
 			br.close();

--- a/src/main/java/com/diffbot/wikistatsextractor/util/Util.java
+++ b/src/main/java/com/diffbot/wikistatsextractor/util/Util.java
@@ -49,7 +49,7 @@ public class Util {
 		String patternStr = "<text.*xml:space=\"preserve\">";
 		Pattern patternIndex = Pattern.compile(patternStr);
 		Matcher matcherIndex = patternIndex.matcher(page);
-		//int index_text = page.indexOf("<text xml:space=\"preserve\">");
+		//old pattern version: int index_text = page.indexOf("<text xml:space=\"preserve\">");
 		int index_text = -1;
 		String preserve = "";
 		if(matcherIndex.find()) {

--- a/src/main/java/com/diffbot/wikistatsextractor/util/Util.java
+++ b/src/main/java/com/diffbot/wikistatsextractor/util/Util.java
@@ -6,6 +6,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
  /** some Utils methods */
 public class Util {
@@ -44,10 +46,21 @@ public class Util {
 		}
 
 		/** go to the index of the text */
-		int index_text = page.indexOf("<text xml:space=\"preserve\">");
+		String patternStr = "<text.*xml:space=\"preserve\">";
+		Pattern patternIndex = Pattern.compile(patternStr);
+		Matcher matcherIndex = patternIndex.matcher(page);
+		//int index_text = page.indexOf("<text xml:space=\"preserve\">");
+		int index_text = -1;
+		String preserve = "";
+		if(matcherIndex.find()) {
+			index_text = matcherIndex.start();
+			preserve = page.substring(index_text,matcherIndex.end());
+			//System.out.println(preserve + "...");
+		}
 		if (index_text == -1)
 			return null;
-		index_text += "<text xml:space=\"preserve\">".length();
+		//index_text += "<text xml:space=\"preserve\">".length();
+		index_text += preserve.length();
 
 		/** locate the end */
 		int end_text = page.indexOf("</text>");


### PR DESCRIPTION
This problem is related to an update in the template of the Wikipedia dump files. 

<page>
    <title>dog</title>
    <ns>0</ns>
    <id>3649675</id>
    <revision>
      <id>20020085</id>
      <parentid>19723824</parentid>
      <timestamp>2013-03-27T10:06:11Z</timestamp>
      <contributor>
        <username>Angr</username>
        <id>4237</id>
      </contributor>
      <minor />
      <comment>/* Translations */ sort Old Irish</comment>
      <text xml:space="preserve">{{also|DOG|dög}}

      The last line was replace with something like the following:

<text bytes="83432" xml:space="preserve">{{short description|Political philosophy and movement}} 

      Originally the system only recognize <text xml:space="preserve"> and was unable to recognize the new update version. 

      The new update adds pattern matching as a solution to this problem.